### PR TITLE
v0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.haxelib/
+.vscode/

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,12 @@
+{
+  "name": "heat_ecs",
+  "description": "An Entity-Component-System library",
+  "url" : "https://github.com/mrrogge/heat_ecs",
+  "license": "MIT",
+  "tags": [],
+  "version": "0.1.1",
+  "releasenote": "",
+  "contributors": ["mrrogge"],
+  "dependencies": {},
+  "classPath": "src"
+}

--- a/src/heat/ecs/ComMap.hx
+++ b/src/heat/ecs/ComMap.hx
@@ -1,0 +1,236 @@
+package heat.ecs;
+
+import haxe.ds.Either;
+
+/**
+    Underlying type for `ComMap`. Included here for completeness; there is no need to use this class directly.
+**/
+@:allow(heat.ecs.ComMapKeyIterator)
+class ComMapInternal<T> implements IComMap<T> {
+    /**
+        Holds component instances that are mapped to `Int` `EntityId`s.
+    **/
+    var iMap = new Map<Int, T>();
+    /**
+        Contains every `Int` key currently in `iMap`. Allows stateless iteration of those keys without needing to build a `keys()` iterator.
+    **/
+    var iArray = new Array<Null<Int>>();
+    /**
+        Holds component instances that are mapped to `String` `EntityId`s.
+    **/
+    var sMap = new Map<String, T>();
+    /**
+        Contains every `String` key currently in `sMap`. Allows stateless iteration of those keys without needing to build a `keys()` iterator.
+    **/
+    var sArray = new Array<String>();
+
+    /**
+        The internal key iterator instance. This iterator gets reused, rather than building and throwing one away each loop. Because `ComMap` will likely be iterating within a game loop, this helps prevent unnecessary garbage collection cycles.
+    **/
+    var _keys:ComMapKeyIterator<T>;
+
+    public function new() {
+        _keys = new ComMapKeyIterator(this);
+    }
+
+    @:inheritDoc(IComMap.get)
+    public function get(id:EntityId):Null<T> {
+        switch (id) {
+            case Left(strId): {
+                return this.sMap[strId];
+            }
+            case Right(intId): {
+                return this.iMap[intId];
+            }
+        }
+    }
+
+    /**
+        See `ComMap.set`.
+    **/
+    public function set(id:EntityId, com:T):Void {
+        switch (id) {
+            case Left(strId): {
+                if (com == null) {
+                    if (this.sMap[strId] != null) {
+                        this.sArray.remove(strId);
+                    }
+                    else {/* already removed */}
+                }
+                else {
+                    if (this.sMap[strId] == null) {
+                        this.sArray.push(strId);
+                    }
+                    else { /* already added */}
+                }
+                this.sMap[strId] = com;
+            }
+            case Right(intId): {
+                if (com == null) {
+                    if (this.iMap[intId] != null) {
+                        this.iArray.remove(intId);
+                    }
+                    else {/* already removed */}
+                }
+                else {
+                    if (this.iMap[intId] == null) {
+                        this.iArray.push(intId);
+                    }
+                    else { /* already added */}
+                }
+                this.iMap[intId] = com;
+            }
+        }
+    }
+
+    /**
+        Removes a component instance for a given `id`.
+        @param id The `EntityId` key.
+    **/
+    inline public function remove(id:EntityId):Void {
+        return this.set(id, null);
+    }
+
+    @:inheritDoc(IComMap.exists)
+    public function exists(id:EntityId):Bool {
+        switch (id) {
+            case Left(strId): {
+                return this.sMap[strId] != null;
+            }
+            case Right(intId): {
+                return this.iMap[intId] != null;
+            }
+        }
+    }
+
+    @:inheritDoc(IComMap.keys)
+    public function keys():Iterator<EntityId> {
+        return _keys;
+    }
+}
+
+/**
+    A map of `EntityId`s to component instances. Components can be any type (specified by the `T` parameter).
+**/
+@:forward
+@:forward.new
+abstract ComMap<T>(ComMapInternal<T>) from ComMapInternal<T> to ComMapInternal<T> {
+    @:inheritDoc(IComMap.get)
+    @:arrayAccess
+    public inline function getCom(id:EntityId) {
+        return this.get(id);
+    }
+
+    /**
+        Sets a component instance `com` for a given `id`.
+        If a component already exists, it is replaced by the new `com`.
+        @param id The `EntityId key.
+        @param com The component instance.
+    **/
+    @:arrayAccess
+    public inline function setCom(id:EntityId, com:T) {
+        return this.set(id, com);
+    }
+}
+
+private class ComMapKeyIterator<T> {
+    var map:ComMap<T>;
+    var i = 0;
+    var state:ComMapKeyIteratorState = INTS;
+
+    public function new(map:ComMap<T>) {
+        this.map = map;
+    }
+
+    inline function checkIfEmpty() {
+        switch state {
+            case EMPTY: {
+                if (map.iArray.length > 0 || map.sArray.length > 0) {
+                    state = INTS;
+                }
+            }
+            default: {
+                if (map.iArray.length == 0 && map.sArray.length == 0) {
+                    state = EMPTY;
+                }
+            }
+        }
+    }
+
+    inline function checkNextInt():haxe.ds.Option<Int> {
+        if (map.iArray.length == 0) return None;
+        if (map.iArray[i] == null) return None;
+        return Some(map.iArray[i]);
+    }
+
+    inline function checkNextString():haxe.ds.Option<String> {
+        if (map.sArray.length == 0) return None;
+        if (map.sArray[i] == null) return None;
+        return Some(map.sArray[i]);
+    }
+
+    public function hasNext():Bool {
+        checkIfEmpty();
+        switch state {
+            case EMPTY: return false;
+            case DONE: {
+                state = INTS;
+                i = 0;
+                return false;
+            }
+            default: return true;
+        }
+    }
+
+    public function next():EntityId {
+        var id:EntityId = null;
+        while (true) {
+            switch state {
+                case INTS: {
+                    switch checkNextInt() {
+                        case Some(int): {
+                            if (id == null) {
+                                id = int;
+                                i++;
+                            }
+                            else break;
+                        }
+                        case None: {
+                            state = STRINGS;
+                            i = 0;
+                        }
+                    }
+                }
+                case STRINGS: {
+                    switch checkNextString() {
+                        case Some(str): {
+                            if (id == null) {
+                                id = str;
+                                i++;
+                            }
+                            else break;
+                        }
+                        case None: {
+                            state = DONE;
+                            i = 0;
+                        }
+                    }
+                }
+                case EMPTY, DONE: break;
+            }
+        }
+        if (id == null) throw new haxe.Exception("problem with iteration");
+        return id;
+    }
+
+    public inline function iterator():ComMapKeyIterator<T> {
+        return this;
+    }
+}
+
+private enum abstract ComMapKeyIteratorState(Int) {
+    var INTS;
+    var STRINGS;
+    var DONE;
+    var EMPTY;
+}

--- a/src/heat/ecs/ComQuery1.hx
+++ b/src/heat/ecs/ComQuery1.hx
@@ -1,0 +1,50 @@
+package heat.ecs;
+
+import haxe.ds.Either;
+
+/**
+    An implementation of `IComQuery` for a single `ComMap`.
+**/
+class ComQuery1<T0> implements IComQuery {
+
+    public var map0(default, null):IComMap<T0>;
+
+    @:inheritDoc(IComQuery.result)
+    public var result(default, null) = new Array<EntityId>();
+
+    public function new(map0:IComMap<T0>) {
+        this.map0 = map0;
+    }
+
+    @:inheritDoc(IComQuery.run)
+    public function run():Array<EntityId> {
+        while (result.length > 0) result.pop();
+        for (id in map0.keys()) {
+            result.push(id);
+        }
+        return this.result;
+    }
+
+    @:inheritDoc(IComQuery.hasAll)
+    public function hasAll(id:EntityId):Bool {
+        return this.map0.exists(id);
+    }
+
+    /**
+        Returns a `Tuple1` of a component for a given `id` corresponding to the query's `ComMap`. The component may be null if it does not exist for `id`.
+
+        If a `tuple` argument is passed, the component will be applied to that instance and returned. Otherwise, a new `Tuple1` instance will be constructed and returned.
+
+        @param id The entity identifier to check.
+
+        @param tuple An existing tuple to reuse, if desired.
+    **/
+    public function getComTuple(id:EntityId, ?tuple:Tuple1<T0>):Tuple1<T0> {
+        var returnedTuple = {
+            if (tuple != null) tuple
+            else new Tuple1();
+        };
+        returnedTuple.e0 = this.map0.get(id);
+        return returnedTuple;
+    }
+}

--- a/src/heat/ecs/ComQuery2.hx
+++ b/src/heat/ecs/ComQuery2.hx
@@ -1,0 +1,53 @@
+package heat.ecs;
+
+import haxe.ds.Either;
+
+/**
+    An implementation of `IComQuery` for two `ComMap`s.
+**/
+class ComQuery2<T0, T1> implements IComQuery {
+    public var map0(default, null):IComMap<T0>;
+    public var map1(default, null):IComMap<T1>;
+
+    @:inheritDoc(IComQuery.result)
+    public var result(default, null) = new Array<EntityId>();
+
+    public function new(map0:IComMap<T0>, map1:IComMap<T1>) {
+        this.map0 = map0;
+        this.map1 = map1;
+    }
+
+    @:inheritDoc(IComQuery.run)
+    public function run():Array<EntityId> {
+        while (result.length > 0) result.pop();
+        for (id in map0.keys()) {
+            if (map1.exists(id)) {
+                result.push(id);
+            }
+        }
+        return this.result;
+    }
+
+    @:inheritDoc(IComQuery.hasAll)
+    public function hasAll(id:EntityId):Bool {
+        return map0.exists(id) && map1.exists(id);
+    }
+
+    /**
+        Returns a `Tuple2` of components for a given `id` corresponding to the query's `ComMap`s. One or more components may be null if they do not exist for `id`.
+
+        If a `tuple` argument is passed, the components will be applied to that instance and returned. Otherwise, a new `Tuple2` instance will be constructed and returned.
+
+        @param id The entity identifier to check.
+
+        @param tuple An existing tuple to reuse, if desired.
+    **/
+    public function getComTuple(id:EntityId, ?tuple:Tuple2<T0, T1>):Tuple2<T0, T1> {
+        var returnedTuple = {
+            if (tuple != null) tuple
+            else new Tuple2();
+        };
+        returnedTuple.init(map0.get(id), map1.get(id));
+        return returnedTuple;
+    }
+}

--- a/src/heat/ecs/ComQuery3.hx
+++ b/src/heat/ecs/ComQuery3.hx
@@ -1,0 +1,55 @@
+package heat.ecs;
+
+import haxe.ds.Either;
+
+/**
+    An implementation of `IComQuery` for three `ComMap`s.
+**/
+class ComQuery3<T0, T1, T2> implements IComQuery {
+    public var map0(default, null):IComMap<T0>;
+    public var map1(default, null):IComMap<T1>;
+    public var map2(default, null):IComMap<T2>;
+
+    @:inheritDoc(IComQuery.result)
+    public var result(default, null) = new Array<EntityId>();
+
+    public function new(map0:IComMap<T0>, map1:IComMap<T1>, map2:IComMap<T2>) {
+        this.map0 = map0;
+        this.map1 = map1;
+        this.map2 = map2;
+    }
+
+    @:inheritDoc(IComQuery.run)
+    public function run():Array<EntityId> {
+        while (result.length > 0) result.pop();
+        for (id in map0.keys()) {
+            if (map1.exists(id) && map2.exists(id)) {
+                result.push(id);
+            }
+        }
+        return this.result;
+    }
+
+    @:inheritDoc(IComQuery.hasAll)
+    public function hasAll(id:EntityId):Bool {
+        return map0.exists(id) && map1.exists(id) && map2.exists(id);
+    }
+
+    /**
+        Returns a `Tuple3` of components for a given `id` corresponding to the query's `ComMap`s. One or more components may be null if they do not exist for `id`.
+
+        If a `tuple` argument is passed, the components will be applied to that instance and returned. Otherwise, a new `Tuple3` instance will be constructed and returned.
+
+        @param id The entity identifier to check.
+
+        @param tuple An existing tuple to reuse, if desired.
+    **/
+    public function getComTuple(id:EntityId, ?tuple:Tuple3<T0, T1, T2>):Tuple3<T0, T1, T2> {
+        var returnedTuple = {
+            if (tuple != null) tuple
+            else new Tuple3();
+        };
+        returnedTuple.init(map0.get(id), map1.get(id), map2.get(id));
+        return returnedTuple;
+    }
+}

--- a/src/heat/ecs/ComQuery4.hx
+++ b/src/heat/ecs/ComQuery4.hx
@@ -1,0 +1,57 @@
+package heat.ecs;
+
+import haxe.ds.Either;
+
+/**
+    An implementation of `IComQuery` for four `ComMap`s.
+**/
+class ComQuery4<T0, T1, T2, T3> implements IComQuery {
+    public var map0(default, null):IComMap<T0>;
+    public var map1(default, null):IComMap<T1>;
+    public var map2(default, null):IComMap<T2>;
+    public var map3(default, null):IComMap<T3>;
+
+    @:inheritDoc(IComQuery.result)
+    public var result(default, null) = new Array<EntityId>();
+
+    public function new(map0:IComMap<T0>, map1:IComMap<T1>, map2:IComMap<T2>, map3:IComMap<T3>) {
+        this.map0 = map0;
+        this.map1 = map1;
+        this.map2 = map2;
+        this.map3 = map3;
+    }
+
+    @:inheritDoc(IComQuery.run)
+    public function run():Array<EntityId> {
+        while (result.length > 0) result.pop();
+        for (id in map0.keys()) {
+            if (map1.exists(id) && map2.exists(id) && map3.exists(id)) {
+                result.push(id);
+            }
+        }
+        return this.result;
+    }
+
+    @:inheritDoc(IComQuery.hasAll)
+    public function hasAll(id:EntityId):Bool {
+        return map0.exists(id) && map1.exists(id) && map2.exists(id) && map3.exists(id);
+    }
+
+    /**
+        Returns a `Tuple4` of components for a given `id` corresponding to the query's `ComMap`s. One or more components may be null if they do not exist for `id`.
+
+        If a `tuple` argument is passed, the components will be applied to that instance and returned. Otherwise, a new `Tuple4` instance will be constructed and returned.
+
+        @param id The entity identifier to check.
+
+        @param tuple An existing tuple to reuse, if desired.
+    **/
+    public function getComTuple(id:EntityId, ?tuple:Tuple4<T0, T1, T2, T3>):Tuple4<T0, T1, T2, T3> {
+        var returnedTuple = {
+            if (tuple != null) tuple
+            else new Tuple4();
+        };
+        returnedTuple.init(map0.get(id), map1.get(id), map2.get(id), map3.get(id));
+        return returnedTuple;
+    }
+}

--- a/src/heat/ecs/ComStore.hx
+++ b/src/heat/ecs/ComStore.hx
@@ -1,0 +1,93 @@
+package heat.ecs;
+
+/**
+    Underlying type for `ComStore`. Included here for completeness; there is no need to use this class directly.
+**/
+class ComStoreInternal<TCom, TData> implements IComMap<TCom> {
+    var map = new ComMap<TCom>();
+    var pool:Pool<TCom, TData>;
+
+    /**
+        Constructs a new instance. 
+
+        @param constructor a method that builds and returns a new `TCom` instance when called. See `Pool`.
+        @param init a method that initializes a `TCom` instance when called. See `Pool`.
+    **/
+    public function new(constructor:(?data:TData)->TCom, 
+    ?init:(instance:TCom, ?data:TData)->Void) {
+        pool = new Pool<TCom, TData>(constructor, init);
+    }
+
+    /**
+        Adds a component for an entity.
+
+        If no component currently exists, an instance will be mapped to the `EntityId`. Otherwise, if the entity already has a component instance, the component will be initialized using the `data` parameter.
+    **/
+    public function add(id:EntityId, ?data:TData):TCom {
+        if (map.exists(id)) {
+            pool._init(map[id], data);
+        }
+        else {
+            map[id] = pool.get(data);
+        }
+        return map[id];
+    }
+
+    /**
+        Removes a component from an entity.
+
+        The instance is returned to the internal `Pool`, so make sure not to reference the instance once removed, otherwise conflicts may occur.
+    **/
+    public function remove(id:EntityId) {
+        if (map.exists(id)) {
+            pool.put(map[id]);
+            map[id] = null;
+        }
+    }
+
+    @:inheritDoc(IComMap.get)
+    public function get(id:EntityId):TCom {
+        return map[id];
+    }
+
+    @:inheritDoc(IComMap.set)
+    public function set(id:EntityId, com:TCom):Void {
+        map.set(id, com);
+    }
+
+    @:inheritDoc(IComMap.exists)
+    public function exists(id:EntityId):Bool {
+        return map[id] != null;
+    }
+
+    @:inheritDoc(IComMap.keys)
+    public function keys():Iterator<EntityId> {
+        return map.keys();
+    }
+
+    /**
+        Flushes the internal pool, removing all old component instances. Components currently mapped to entities are unaffected.
+    **/
+    public function flush() {
+        pool.flush();
+    }
+}
+
+/**
+    A wrapper around a `ComMap` and a corresponding `Pool`. This provides a nice way to manage components while automatically reusing old instances. Because this class implements `IComMap`, it can be passed to a `ComQuery` like any other `ComMap`.
+**/
+@:forward
+@:forward.new
+abstract ComStore<TCom, TData>(ComStoreInternal<TCom, TData>)
+from ComStoreInternal<TCom, TData>
+to ComStoreInternal<TCom, TData> {
+    @:arrayAccess
+    public inline function getCom(id:EntityId):TCom {
+        return this.get(id);
+    }
+
+    @:arrayAccess
+    public inline function setCom(id:EntityId, com:TCom):Void {
+        return this.set(id, com);
+    }
+}

--- a/src/heat/ecs/EntityId.hx
+++ b/src/heat/ecs/EntityId.hx
@@ -1,0 +1,48 @@
+package heat.ecs;
+
+import haxe.ds.Either;
+
+/**
+    An identifier for an entity.
+**/
+abstract EntityId(Either<String, Int>) from Either<String, Int> 
+to Either<String, Int> {
+    @:from
+    inline public static function fromString(s:String):EntityId {
+        return Left(s);
+    }
+
+    @:from
+    inline public static function fromInt(i:Int):EntityId {
+        return Right(i);
+    }
+
+    @:to
+    inline public function toString():String {
+        return switch (this) {
+            case Left(s): 'ID($s)';
+            case Right(i): 'ID($i)';
+        }
+    }
+
+    @:to
+    inline public function toInt():Null<Int> {
+        return switch (this) {
+            case Left(s): null;
+            case Right(i): return i;
+        }
+    }
+
+    @:op(a == b) public static inline function eq(a:EntityId, b:EntityId):Bool {
+        return switch a {
+            case Left(a): switch b {
+                case Left(b): a == b;
+                case Right(b): false;
+            }
+            case Right(a): switch b{
+                case Left(b): false;
+                case Right(b): a == b;
+            }
+        }
+    }
+}

--- a/src/heat/ecs/IComMap.hx
+++ b/src/heat/ecs/IComMap.hx
@@ -1,0 +1,25 @@
+package heat.ecs;
+
+/**
+    An interface for a map of `EntityId`s to component instances.
+**/
+interface IComMap<T> {
+    /**
+        Returns the component instance for a given `id`.
+        @param id The `EntityId` key.
+    **/
+    public function get(id:EntityId):T;
+
+    public function set(id:EntityId, com:T):Void;
+
+    /**
+        Returns `true` if a component instance exists for `id`, otherwise `false`.
+        @param id The `EntityId` key.
+    **/
+    public function exists(id:EntityId):Bool;
+
+    /**
+        Return an iterator over the `EntityId` keys in this map. The order is undefined.
+    **/
+    public function keys():Iterator<EntityId>;
+}

--- a/src/heat/ecs/IComQuery.hx
+++ b/src/heat/ecs/IComQuery.hx
@@ -1,0 +1,23 @@
+package heat.ecs;
+
+/**
+    Interface for component queries. These are used to find all the `EntityId`s that currently have a set of specific components.
+
+    Implementations of `IComQuery` will typically accept `ComMap` instances in their constructors. They then populate an array with all the `EntityId`s that exist for all of those `ComMap` instances. This array is reused, so re-running the query in an update loop will not create junk instances each frame.
+**/
+interface IComQuery {
+    /**
+        After calling run(), this will contain every `EntityId` that is found for all `ComMap`s. The order of elements is undefined.
+    **/
+    public var result(default, null):Array<EntityId>;
+
+    /**
+        Updates the `result` array.
+    **/
+    public function run():Array<EntityId>;
+
+    /**
+        Returns true if the `id` has instances of all components defined for this query (otherwise false).
+    **/
+    public function hasAll(id:EntityId):Bool;
+}

--- a/src/heat/ecs/Pool.hx
+++ b/src/heat/ecs/Pool.hx
@@ -1,0 +1,72 @@
+package heat.ecs;
+
+/**
+    A generic object pool.
+
+    To construct a `Pool` instance, there are three things you must define - an element type (`TElement`), a data type (`TData`), and a constructor function (constructor argument in `new`). 
+        
+    `TElement` is the type of object that will be pooled. This can be any type, although it is intended mainly for classes and anonymous structures.
+
+    `TData` defines relevant data for the `TElement` instances. It is used to construct new `TElement`s and initialize previously-constructed instances.
+
+    The constructor function accepts an instance of `TData` and returns an instance of `TElement`. When a new `TElement` is requested from an empty pool, this constructor function is called and the result is returned. The constructor is often just a wrapper around a `new TElement()` call, passing values from the `TData` into the "inner" constructor's arguments (if any). This abstraction allows us to pool any class type, regardless of their actual constructor arguments, without resorting to a subclass of `Pool`.
+
+    An optional init function can be passed as well. This accepts a `TElement` and a `TData`, and is intended to apply the `TData` values onto the `TElement`. This is used when retrieving an existing `TElement` from the `Pool` such that the `TElement` is reset to a known initial state.
+**/
+class Pool<TElement, TData> {
+    var stack = new haxe.ds.GenericStack<TElement>();
+    var _constructor:(?data:TData)->TElement;
+    
+    @:allow(heat.ecs.ComStoreInternal)
+    var _init:(instance:TElement, ?data:TData)->Void;
+
+    function defaultInit(instance:TElement, ?data:TData):Void {}
+
+    /**
+        Constructs a new `Pool` instance.
+
+        @param constructor The function used to construct new `TElement`s.
+        @param init The function used to initialize existing `TElement`s.
+    **/
+    public function new(constructor:(?data:TData)->TElement, 
+    ?init:(instance:TElement, ?data:TData)->Void) {
+        this._constructor = constructor;
+        this._init = (init == null) ? defaultInit : init;
+    }
+
+    /**
+        Retrieves a `TElement` from the pool.
+
+        If the pool is empty, a new `TElement` will be returned using the constructor function. Otherwise, an existing `TElement` is removed from the pool, initialized, then returned.
+
+        @param data The data used to either construct or initialize the returned `TElement`.
+    **/
+    public function get(?data:TData):TElement {
+        if (stack.isEmpty()) {
+            return _constructor(data);
+        }
+        else {
+            var instance = stack.pop();
+            _init(instance, data);
+            return instance;
+        }
+    }
+
+    /**
+        Adds an element to the pool. Once an element is returned, it must no longer be referenced in code, otherwise conflicts may occur.
+
+        @param element The element to add.
+    **/
+    public inline function put(element:TElement) {
+        stack.add(element);
+    }
+
+    /**
+        Removes all instances from the pool.
+    **/
+    public function flush() {
+        while (!stack.isEmpty()){
+            stack.pop();
+        }
+    }
+}

--- a/src/heat/ecs/Tuple1.hx
+++ b/src/heat/ecs/Tuple1.hx
@@ -1,0 +1,24 @@
+package heat.ecs;
+
+/**
+    A mutable tuple structure with 1 element.
+**/
+@:expose("Tuple1")
+class Tuple1<T0> {
+    /** Element 0.**/
+    public var e0:T0;
+
+    /**
+        @param e0 Element 0.
+    **/
+    public function new(?e0:T0) {
+        this.init(e0);
+    }
+
+    /**
+        @param e0 Element 0.
+    **/
+    public inline function init(?e0:T0) {
+        this.e0 = e0;
+    }
+}

--- a/src/heat/ecs/Tuple2.hx
+++ b/src/heat/ecs/Tuple2.hx
@@ -1,0 +1,29 @@
+package heat.ecs;
+
+/**
+    A mutable tuple structure with two elements.
+**/
+@:expose("Tuple2")
+class Tuple2<T0, T1> {
+    /** Element 0.**/
+    public var e0:T0;
+    /** Element 1.**/
+    public var e1:T1;
+
+    /**
+        @param e0 Element 0.
+        @param e1 Element 1.
+    **/
+    public function new(?e0:T0, ?e1:T1) {
+        this.init(e0, e1);
+    }
+
+    /**
+        @param e0 Element 0.
+        @param e1 Element 1.
+    **/   
+    public inline function init(?e0:T0, ?e1:T1) {
+        this.e0 = e0;
+        this.e1 = e1;
+    }
+}

--- a/src/heat/ecs/Tuple3.hx
+++ b/src/heat/ecs/Tuple3.hx
@@ -1,0 +1,34 @@
+package heat.ecs;
+
+/**
+    A mutable tuple structure with three elements.
+**/
+@:expose("Tuple3")
+class Tuple3<T0, T1, T2> {
+    /** Element 0.**/
+    public var e0:T0;
+    /** Element 1.**/
+    public var e1:T1;
+    /** Element 2.**/
+    public var e2:T2;
+
+    /**
+        @param e0 Element 0.
+        @param e1 Element 1.
+        @param e2 Element 2.
+    **/
+    public function new(?e0:T0, ?e1:T1, ?e2:T2) {
+        this.init(e0, e1, e2);
+    }
+
+    /**
+        @param e0 Element 0.
+        @param e1 Element 1.
+        @param e2 Element 2.
+    **/   
+    public inline function init(?e0:T0, ?e1:T1, ?e2:T2) {
+        this.e0 = e0;
+        this.e1 = e1;
+        this.e2 = e2;
+    }
+}

--- a/src/heat/ecs/Tuple4.hx
+++ b/src/heat/ecs/Tuple4.hx
@@ -1,0 +1,39 @@
+package heat.ecs;
+
+/**
+    A mutable tuple structure with four elements.
+**/
+@:expose("Tuple4")
+class Tuple4<T0, T1, T2, T3> {
+    /** Element 0.**/
+    public var e0:T0;
+    /** Element 1.**/
+    public var e1:T1;
+    /** Element 2.**/
+    public var e2:T2;
+    /** Element 3.**/
+    public var e3:T3;
+
+    /**
+        @param e0 Element 0.
+        @param e1 Element 1.
+        @param e2 Element 2.
+        @param e3 Element 3.
+    **/
+    public function new(?e0:T0, ?e1:T1, ?e2:T2, ?e3:T3) {
+        this.init(e0, e1, e2, e3);
+    }
+
+    /**
+        @param e0 Element 0.
+        @param e1 Element 1.
+        @param e2 Element 2.
+        @param e3 Element 3.
+    **/   
+    public inline function init(?e0:T0, ?e1:T1, ?e2:T2, ?e3:T3) {
+        this.e0 = e0;
+        this.e1 = e1;
+        this.e2 = e2;
+        this.e3 = e3;
+    }
+}

--- a/test.hxml
+++ b/test.hxml
@@ -1,0 +1,7 @@
+-cp src
+-cp test
+-L buddy
+-D analyzer-optimize
+-D buddy-colors
+--interp
+--main Main

--- a/test/Main.hx
+++ b/test/Main.hx
@@ -1,0 +1,125 @@
+using buddy.Should;
+using Lambda;
+
+class Main extends buddy.SingleSuite {
+    public function new() {
+        describe("ComQueries find all EntityIds with all components: ", {
+            describe("given two ComMaps", {
+                var map0 = new heat.ecs.ComMap<{}>();
+                var map1 = new heat.ecs.ComMap<{}>();
+
+                describe("and two entities with both components", {
+                    var id0 = 0;
+                    var id1 = 1;
+                    map0[id0] = {};
+                    map0[id1] = {};
+                    map1[id0] = {};
+                    map1[id1] = {};
+
+                    it("a ComQuery result includes both entities.", {
+                        var comQuery = new heat.ecs.ComQuery2(map0, map1);
+                        comQuery.run();
+                        //for some reason contain() and containAll() are not working with abstracts over enums, e.g:
+                        //comQuery.result.should.containAll([id0, id1]);
+                        //for now we just check item existence explicitly:
+                        comQuery.result.exists(function(item) return item == id0).should.be(true);
+                        comQuery.result.exists(function(item) return item == id1).should.be(true);
+                    });
+                });
+            });
+        });
+            
+        describe("ComQueries do not include EntityIds with missing components", {
+            describe("given two ComMaps", {
+                var map0 = new heat.ecs.ComMap<{}>();
+                var map1 = new heat.ecs.ComMap<{}>();
+
+                describe("and an entity with only one of the components", {
+                    var id = 0;
+                    map0[id] = {};
+
+                    it("a ComQuery result should be empty", {
+                        var comQuery = new heat.ecs.ComQuery2(map0, map1);
+                        comQuery.run();
+                        comQuery.result.exists(function(item) return item == id).should.be(false);
+                    });
+                });
+            });
+        });
+
+        describe("ComQueries provide tuples of an entity's components: ", {
+            describe("given an entity with two components", {
+                var com0 = {value:0};
+                var com1 = {value:1};
+                var map0 = new heat.ecs.ComMap();
+                var map1 = new heat.ecs.ComMap();
+                var id = 0;
+                map0[id] = com0;
+                map1[id] = com1;
+                
+                it("a ComQuery should return a tuple containing both components", {
+                    var comQuery = new heat.ecs.ComQuery2(map0, map1);
+                    var comTuple = comQuery.getComTuple(id);
+                    comTuple.e0.should.be(com0);
+                    comTuple.e1.should.be(com1);
+                });
+            });
+
+            describe("given an entity with only one of two components", {
+                var com0 = {value:0};
+                var map0 = new heat.ecs.ComMap();
+                var map1 = new heat.ecs.ComMap<{}>();
+                var id = 0;
+                map0[id] = com0;
+                
+                it("a ComQuery should return a tuple containing the entity's component and a null", {
+                    var comQuery = new heat.ecs.ComQuery2(map0, map1);
+                    var comTuple = comQuery.getComTuple(id);
+                    comTuple.e0.should.be(com0);
+                    comTuple.e1.should.be(null);
+                });
+            });
+        });
+
+        describe("ComQueries reuse passed tuples when calling getComTuple(): ", {
+            describe("given an entity with a component in a ComMap", {
+                var map = new heat.ecs.ComMap();
+                var id = 0;
+                var com = {};
+                map[id] = com;
+
+                describe("and a ComQuery over that ComMap", {
+                    var comQuery = new heat.ecs.ComQuery1(map);
+
+                    it("the same tuple passed to getComTuple() should be returned", {
+                        var comTuple = new heat.ecs.Tuple1<{}>();
+                        comQuery.getComTuple(id, comTuple).should.be(comTuple);
+                    });
+
+                    it("an empty tuple passed to getComTuple() should have the component added", {
+                        var comTuple = new heat.ecs.Tuple1<{}>();
+                        comQuery.getComTuple(id, comTuple).e0.should.be(com);
+                    });
+                });
+            });
+        });
+
+        describe("ComStores reuse components: ", {
+            describe("given an empty ComStore", {
+                var comStore = new heat.ecs.ComStore((?data:{}) -> return {});
+
+                describe("and a component for an entity has been added and removed", {
+                    var id = 1;
+                    var com = comStore.add(id);
+                    comStore.remove(id);
+
+                    it("adding a component for a new entity should reuse the previous component", {
+                        var otherId = 2;
+                        var otherCom = comStore.add(otherId);
+                        otherCom.should.be(com);
+                    });
+                });
+            });
+        });
+    };
+}


### PR DESCRIPTION
This PR is for the "original" library I started in a different repo. This version will be "0.1.1", but it is mainly for historical purposes, as I've decided to go in a different direction than what I've started here. I'm creating this PR just as a way to get my thoughts out there while they're still fresh.

The main idea was to store components in a generic `ComMap`, for any type. These map an `EntityId` to a single component of that type. Then, the `ComQuery` classes would determine which `EntityId`s had components defined for a set of `ComMap`s. In order to keep type-safety, I had to rely on `Tuple`s depending on how many different `ComMap`s were queried (that's why there's a `ComQuery1`, `ComQuery2`, etc).

This seemed good at first, but in practice I found it pretty cumbersome, having to worry about how many coms were being checked, etc. I still see value in have a type-safe, no-`Dynamic` solution for this, but so far I don't have a good solution in mind that doesn't involve `Dynamic`.

Another point to mention: when I first worked on this, I put a lot of effort into making the key iterators for `ComMap`s stateless. I wanted to avoid creating a brand-new iterator object each time the query was run, because doing that for every query every frame could be bad for performance (e.g. pushing the GC too hard, slowing down frames). Coming from Lua and LOVE2D, I ran into this a lot, so I was trying to stay ahead of the problem.

However, so far working in Haxe, I haven't had these same issues with garbage collection and frame rates. I think the GC algorithms are just better in general than what I've been used to, so for the next version, I'm not going to worry so much about this optimization - it just makes the code harder to follow.

Anyway, that covers most of the important stuff for this version. I will be moving away from this approach, but if I have second-thoughts later on I can always come back and re-evaluate.

